### PR TITLE
🧪 Add tests for check_certs configuration logic

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import patch
+import main
+
+@pytest.mark.asyncio
+async def test_check_certs_reverse_proxy_true():
+    with patch('main.REVERSE_PROXY', True):
+        with patch('main.logger.info') as mock_info:
+            await main.check_certs(main.app, None)
+            mock_info.assert_called_once_with("Running behind reverse proxy - SSL disabled")
+
+@pytest.mark.asyncio
+async def test_check_certs_reverse_proxy_false_no_certs():
+    with patch('main.REVERSE_PROXY', False):
+        with patch('main.CERTS_DIR', 'nonexistent_certs_dir'):
+            with patch('main.logger.warning') as mock_warning:
+                await main.check_certs(main.app, None)
+                mock_warning.assert_called_once()
+                assert "SSL certificates not found" in mock_warning.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_check_certs_reverse_proxy_false_with_certs(tmp_path):
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "fullchain.pem").touch()
+    (certs_dir / "privkey.pem").touch()
+
+    with patch('main.REVERSE_PROXY', False):
+        with patch('main.CERTS_DIR', str(certs_dir)):
+            with patch('main.logger.warning') as mock_warning:
+                await main.check_certs(main.app, None)
+                mock_warning.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_check_certs_reverse_proxy_false_missing_privkey(tmp_path):
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "fullchain.pem").touch()
+
+    with patch('main.REVERSE_PROXY', False):
+        with patch('main.CERTS_DIR', str(certs_dir)):
+            with patch('main.logger.warning') as mock_warning:
+                await main.check_certs(main.app, None)
+                mock_warning.assert_called_once()
+                assert "SSL certificates not found" in mock_warning.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_check_certs_reverse_proxy_false_missing_fullchain(tmp_path):
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "privkey.pem").touch()
+
+    with patch('main.REVERSE_PROXY', False):
+        with patch('main.CERTS_DIR', str(certs_dir)):
+            with patch('main.logger.warning') as mock_warning:
+                await main.check_certs(main.app, None)
+                mock_warning.assert_called_once()
+                assert "SSL certificates not found" in mock_warning.call_args[0][0]


### PR DESCRIPTION
🎯 **What:** The testing gap for the `check_certs` function in `main.py` has been fully addressed by adding a robust test suite.

📊 **Coverage:** The new tests in `test_main.py` cover all variations of environment configuration handling:
* When `REVERSE_PROXY` is enabled (ignores cert checks and logs info).
* When `REVERSE_PROXY` is disabled and the certs directory is completely missing.
* When `REVERSE_PROXY` is disabled and all required certs (`fullchain.pem`, `privkey.pem`) exist.
* When `REVERSE_PROXY` is disabled and a required certificate file (`privkey.pem` or `fullchain.pem`) is missing.

✨ **Result:** Test coverage for `main.py` is increased, ensuring reliable environment parsing and early warning generation when SSL certificates are improperly configured for non-proxy setups. This prevents regressions in application startup logic.

---
*PR created automatically by Jules for task [9242882760572122335](https://jules.google.com/task/9242882760572122335) started by @sleyv*