### PR TITLE
⚡ Optimize randSuffix performance by batching crypto.getRandomValues

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+
+// mock crypto.getRandomValues using node's crypto
+const nodeCrypto = require('crypto');
+global.crypto = {
+    getRandomValues: function(buffer) {
+        const rand = nodeCrypto.randomBytes(buffer.length);
+        buffer.set(rand);
+        return buffer;
+    }
+};
+
+// current code
+function randSuffix(n){const chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';let s='';const max=Math.floor(256/chars.length)*chars.length;const a=new Uint8Array(1);for(let i=0;i<n;i++){do{crypto.getRandomValues(a)}while(a[0]>=max);s+=chars[a[0]%chars.length];}return s}
+
+// proposed code
+function randSuffixOptimized(n){const chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';let s='';const max=Math.floor(256/chars.length)*chars.length;const a=new Uint8Array(n);crypto.getRandomValues(a);let idx=0;for(let i=0;i<n;i++){let r;do{if(idx>=n){crypto.getRandomValues(a);idx=0}r=a[idx++];}while(r>=max);s+=chars[r%chars.length];}return s}
+
+// bench
+const ITERS = 100000;
+const N = 32;
+
+console.log("Benchmarking current implementation...");
+console.time("current");
+for (let i=0; i<ITERS; i++) {
+    randSuffix(N);
+}
+console.timeEnd("current");
+
+console.log("Benchmarking optimized implementation...");
+console.time("optimized");
+for (let i=0; i<ITERS; i++) {
+    randSuffixOptimized(N);
+}
+console.timeEnd("optimized");

--- a/index.html
+++ b/index.html
@@ -1128,7 +1128,7 @@
       function makeQRFixed(version,ecc,data){const qr=qrcode(version,ecc);let str='';for(let i=0;i<data.length;i++)str+=String.fromCharCode(data[i]);qr.addData(str,'Byte');qr.make();return qr}
       function renderQR(qr){const svg=qr.createSvgTag({cellSize:4,margin:4});document.getElementById('qrOut').innerHTML=svg}
 
-      function randSuffix(n){const chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';let s='';const max=Math.floor(256/chars.length)*chars.length;const a=new Uint8Array(1);for(let i=0;i<n;i++){do{crypto.getRandomValues(a)}while(a[0]>=max);s+=chars[a[0]%chars.length];}return s}
+      function randSuffix(n){const chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';let s='';const max=Math.floor(256/chars.length)*chars.length;const a=new Uint8Array(n);crypto.getRandomValues(a);let idx=0;for(let i=0;i<n;i++){let r;do{if(idx>=n){crypto.getRandomValues(a);idx=0}r=a[idx++];}while(r>=max);s+=chars[r%chars.length];}return s}
 
       async function exportQRasPNG(returnBlob = false) {
         const svg = document.querySelector('#qrOut svg');


### PR DESCRIPTION
💡 **What:** The optimization implemented
The `randSuffix(n)` function in `index.html` was refactored to pre-allocate a `Uint8Array` of size `n` and call `crypto.getRandomValues(a)` once, instead of looping `n` times and calling it for a single byte on each iteration. A refill mechanism is included to fetch more random values if a byte is rejected due to modulo bias prevention.

🎯 **Why:** The performance problem it solves
Repeatedly calling `crypto.getRandomValues` incurs high overhead due to boundary crossings between JavaScript and the native cryptographic implementations. Fetching a single byte per call in a loop for a length `n` string significantly drags down performance. Batching random byte fetching reduces this overhead by an order of magnitude.

📊 **Measured Improvement:** 
A benchmark script evaluating 100,000 iterations for length `N=32` showed a ~17x reduction in execution time.
Baseline: `11.527s`
Optimized: `680.533ms`

---
*PR created automatically by Jules for task [18211138020048409651](https://jules.google.com/task/18211138020048409651) started by @sleyv*