### PR TITLE
🔒 Fix Unrestricted Static File Serving Vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,18 @@ async def service_worker(request):
 async def manifest(request):
     return await file(f"{BASE_DIR}/manifest.json", mime_type="application/json")
 
-app.static("/", BASE_DIR, index="index.html", name="root")
+@app.get("/", name="root")
+@app.get("/index.html", name="index_html")
+async def index(request):
+    return await file(f"{BASE_DIR}/index.html", mime_type="text/html")
+
+@app.get("/icon-192.png")
+async def icon_192(request):
+    return await file(f"{BASE_DIR}/icon-192.png", mime_type="image/png")
+
+@app.get("/icon-512.png")
+async def icon_512(request):
+    return await file(f"{BASE_DIR}/icon-512.png", mime_type="image/png")
 
 if __name__ == "__main__":
     ssl_enabled = False


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `app.static("/", BASE_DIR, index="index.html", name="root")` call allowed any file in the base directory to be served as a static asset, leading to potential directory traversal and source code exposure. The fix replaces this overly permissive route with explicitly defined `@app.get` routes that strictly serve only safe public assets (`index.html`, `icon-192.png`, `icon-512.png`). 

⚠️ **Risk:** The potential impact if left unfixed
An attacker could retrieve arbitrary files stored within the application's root directory, including sensitive files like `main.py`, `.env` files, Docker configurations, and potentially TLS certificates if the server was configured insecurely or `BASE_DIR` overlapped with sensitive storage locations.

🛡️ **Solution:** How the fix addresses the vulnerability
Instead of allowing dynamic resolution of any file path matching the URL, the routing logic has been restricted to specifically whitelist the exact files required for the PWA front-end to operate correctly. Requests to any other paths (e.g., `/main.py`) will safely return a 404 Not Found response, preventing data exposure.

---
*PR created automatically by Jules for task [7386006177870228028](https://jules.google.com/task/7386006177870228028) started by @sleyv*